### PR TITLE
feat: support oh-my-openagent.jsonc with backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ omo-switch type
 # Set global type to SLIM (uses oh-my-opencode-slim.json)
 omo-switch type slim
 
-# Set global type to OMO (uses oh-my-opencode.jsonc)
+# Set global type to OMO (uses oh-my-openagent.jsonc)
 omo-switch type omo
 
 # Set project-specific type override (creates .opencode/settings.json)
@@ -330,8 +330,8 @@ omo-switch schema refresh --offline
 
 | Scope | Storage Location | Target Config Path | Use Case |
 |-------|------------------|-------------------|----------|
-| `user` | `~/.config/omo-switch/` | `~/.config/opencode/oh-my-opencode.jsonc` (OMO) / `~/.config/opencode/oh-my-opencode-slim.json` (OMOS) | Global profiles/presets shared across all projects |
-| `project` | `<project>/.opencode/` | `<project>/.opencode/oh-my-opencode.jsonc` (OMO) / `<project>/.opencode/oh-my-opencode-slim.json` (OMOS) | Project-specific profiles/presets, ideal for team sharing via Git |
+| `user` | `~/.config/omo-switch/` | `~/.config/opencode/oh-my-openagent.jsonc` (OMO) / `~/.config/opencode/oh-my-opencode-slim.json` (OMOS) | Global profiles/presets shared across all projects |
+| `project` | `<project>/.opencode/` | `<project>/.opencode/oh-my-openagent.jsonc` (OMO) / `<project>/.opencode/oh-my-opencode-slim.json` (OMOS) | Project-specific profiles/presets, ideal for team sharing via Git |
 
 
 ## Storage Structure
@@ -353,7 +353,7 @@ omo-switch schema refresh --offline
 <project>/.opencode/
 ├── .omorc               # Project-specific active profile (OMO)
 ├── omo-configs/         # Project-specific profiles (OMO)
-├── oh-my-opencode.jsonc # Applied project config (target) (OMO)
+├── oh-my-openagent.jsonc # Applied project config (target) (OMO)
 └── oh-my-opencode-slim.json # Applied project config (target) (OMOS)
 ```
 
@@ -363,9 +363,9 @@ When applying a profile, `omo-switch` writes to:
 
 | Scope | Platform | Primary Path | Fallback Path |
 |-------|----------|--------------|---------------|
-| `user` | Windows | `%USERPROFILE%\.config\opencode\oh-my-opencode.jsonc` (OMO) / `%USERPROFILE%\.config\opencode\oh-my-opencode-slim.json` (OMOS) | `%APPDATA%\opencode\oh-my-opencode.json` |
-| `user` | Linux/macOS | `$XDG_CONFIG_HOME/opencode/oh-my-opencode.jsonc` (OMO) / `$XDG_CONFIG_HOME/opencode/oh-my-opencode-slim.json` (OMOS) | `~/.config/opencode/oh-my-opencode.jsonc` |
-| `project` | All | `<project>/.opencode/oh-my-opencode.jsonc` (OMO) / `<project>/.opencode/oh-my-opencode-slim.json` (OMOS) | - |
+| `user` | Windows | `%USERPROFILE%\.config\opencode\oh-my-openagent.jsonc` (OMO) / `%USERPROFILE%\.config\opencode\oh-my-opencode-slim.json` (OMOS) | `%APPDATA%\opencode\oh-my-opencode.json` |
+| `user` | Linux/macOS | `$XDG_CONFIG_HOME/opencode/oh-my-openagent.jsonc` (OMO) / `$XDG_CONFIG_HOME/opencode/oh-my-opencode-slim.json` (OMOS) | `~/.config/opencode/oh-my-openagent.jsonc` |
+| `project` | All | `<project>/.opencode/oh-my-openagent.jsonc` (OMO) / `<project>/.opencode/oh-my-opencode-slim.json` (OMOS) | - |
 
 ## Local Development
 
@@ -449,8 +449,8 @@ Ensure your terminal has write permissions to:
 ### Finding Backups
 
 If something goes wrong, find your original configuration in:
-- **Global**: `~/.config/omo-switch/backups/<ISO_TIMESTAMP>__oh-my-opencode.jsonc`
-- **Project**: `<project>/.opencode/backups/<ISO_TIMESTAMP>__oh-my-opencode.jsonc`
+- **Global**: `~/.config/omo-switch/backups/<ISO_TIMESTAMP>__oh-my-openagent.jsonc`
+- **Project**: `<project>/.opencode/backups/<ISO_TIMESTAMP>__oh-my-openagent.jsonc`
 
 ### Backup Retention Policy
 

--- a/src/commands/add.test.ts
+++ b/src/commands/add.test.ts
@@ -123,7 +123,7 @@ vi.mock("../store", () => {
         }
         saveRc() {}
         getTargetPath() {
-          return "/project/.opencode/oh-my-opencode.jsonc";
+          return "/project/.opencode/oh-my-openagent.jsonc";
         }
         listProfiles() {
           return [];

--- a/src/commands/apply.test.ts
+++ b/src/commands/apply.test.ts
@@ -51,6 +51,7 @@ vi.mock("../utils/downloader", () => ({
 vi.mock("../utils/config-path", () => ({
   getConfigTargetDir: vi.fn(),
   ensureConfigDir: vi.fn(),
+  ALL_CONFIG_FILES: ["oh-my-openagent.jsonc", "oh-my-openagent.json", "oh-my-opencode.jsonc", "oh-my-opencode.json"],
 }));
 
 vi.mock("../utils/scope-resolver", async () => {
@@ -109,7 +110,7 @@ describe("applyCommand", () => {
      vi.spyOn(ProjectStoreManager.prototype, "ensureDirectories");
      vi.spyOn(ProjectStoreManager.prototype, "getProfileConfigRaw").mockReturnValue(null);
      vi.spyOn(ProjectStoreManager.prototype, "listProfiles").mockReturnValue([]);
-     vi.spyOn(ProjectStoreManager.prototype, "getTargetPath").mockReturnValue("/project/.opencode/oh-my-opencode.jsonc");
+     vi.spyOn(ProjectStoreManager.prototype, "getTargetPath").mockReturnValue("/project/.opencode/oh-my-openagent.jsonc");
      vi.spyOn(ProjectStoreManager.prototype, "createBackup").mockReturnValue("/project/.opencode/backups/backup.json");
      vi.spyOn(ProjectStoreManager.prototype, "saveRc");
 
@@ -237,7 +238,7 @@ describe("applyCommand", () => {
      vi.mocked(fs.existsSync).mockImplementation((path: string) => {
        if (typeof path === "string") {
          if (path.includes("oh-my-opencode.schema.json")) return true;
-         if (path.includes("oh-my-opencode.jsonc")) return true;
+         if (path.includes("oh-my-openagent.jsonc")) return true;
        }
        return false;
      });
@@ -260,7 +261,7 @@ describe("applyCommand", () => {
      });
      vi.spyOn(ProjectStoreManager.prototype, "ensureDirectories");
      vi.spyOn(ProjectStoreManager.prototype, "saveRc");
-     vi.spyOn(ProjectStoreManager.prototype, "getTargetPath").mockReturnValue("/project/.opencode/oh-my-opencode.jsonc");
+     vi.spyOn(ProjectStoreManager.prototype, "getTargetPath").mockReturnValue("/project/.opencode/oh-my-openagent.jsonc");
      vi.spyOn(ProjectStoreManager.prototype, "createBackup").mockReturnValue("/project/.opencode/backups/backup.json");
      vi.mocked(fs.existsSync).mockImplementation((path: string) => {
        if (typeof path === "string") {
@@ -304,7 +305,7 @@ describe("applyCommand", () => {
      });
      vi.spyOn(ProjectStoreManager.prototype, "ensureDirectories");
      vi.spyOn(ProjectStoreManager.prototype, "saveRc");
-     vi.spyOn(ProjectStoreManager.prototype, "getTargetPath").mockReturnValue("/project/.opencode/oh-my-opencode.jsonc");
+     vi.spyOn(ProjectStoreManager.prototype, "getTargetPath").mockReturnValue("/project/.opencode/oh-my-openagent.jsonc");
      vi.spyOn(ProjectStoreManager.prototype, "createBackup").mockReturnValue("/project/.opencode/backups/backup.json");
      vi.mocked(fs.existsSync).mockImplementation((path: string) => {
        if (typeof path === "string") {

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -6,7 +6,7 @@ import * as path from "path";
 import JSON5 from "json5";
 import { StoreManager, ProjectStoreManager, Scope, OmosConfigManager, SettingsManager } from "../store";
 import { Validator } from "../utils/validator";
-import { getConfigTargetDir, ensureConfigDir } from "../utils/config-path";
+import { getConfigTargetDir, ensureConfigDir, ALL_CONFIG_FILES } from "../utils/config-path";
 import { downloadFile, readBundledAsset } from "../utils/downloader";
 import { resolveProjectRoot, findProjectRoot } from "../utils/scope-resolver";
 
@@ -202,22 +202,21 @@ async function handleOmoApply(
     ensureConfigDir(targetPath);
 
     spinner.text = "Creating backup...";
-    backupPath = projectStore.createBackup(targetPath);
+    const existingTarget = projectStore.findExistingTargetConfig();
+    backupPath = existingTarget ? projectStore.createBackup(existingTarget) : null;
   } else {
-    // User scope: always write to .jsonc file
     spinner.text = "Determining target path...";
     const targetDir = getConfigTargetDir();
-    targetPath = path.join(targetDir.dir, "oh-my-opencode.jsonc");
+    targetPath = path.join(targetDir.dir, "oh-my-openagent.jsonc");
     ensureConfigDir(targetPath);
 
-    // Create backup of existing config (could be .json or .jsonc)
     spinner.text = "Creating backup...";
-    const existingJsonc = path.join(targetDir.dir, "oh-my-opencode.jsonc");
-    const existingJson = path.join(targetDir.dir, "oh-my-opencode.json");
-    if (fs.existsSync(existingJsonc)) {
-      backupPath = globalStore.createBackup(existingJsonc);
-    } else if (fs.existsSync(existingJson)) {
-      backupPath = globalStore.createBackup(existingJson);
+    for (const file of ALL_CONFIG_FILES) {
+      const existingPath = path.join(targetDir.dir, file);
+      if (fs.existsSync(existingPath)) {
+        backupPath = globalStore.createBackup(existingPath);
+        break;
+      }
     }
   }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -133,7 +133,7 @@ export const initCommand = new Command("init")
           // Apply default profile to target config
           spinner.text = "Applying default profile...";
           const targetDir = getConfigTargetDir();
-          const targetPath = path.join(targetDir.dir, "oh-my-opencode.jsonc");
+          const targetPath = path.join(targetDir.dir, "oh-my-openagent.jsonc");
           ensureConfigDir(targetPath);
           
           const headerComment = `// Profile Name: ${profile.name}, edited by omo-switch`;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,6 +6,7 @@ import { StoreManager, SettingsManager, OmosConfigManager } from "../store";
 import { downloadFile, readBundledAsset } from "../utils/downloader";
 import { findExistingConfigPath, getConfigTargetDir, ensureConfigDir } from "../utils/config-path";
 import { getOmosConfigTargetPath } from "../utils/omos-config-path";
+import { resolveProjectRoot, NEW_AGENT_CONFIG_FILE } from "../utils/scope-resolver";
 import * as fs from "fs";
 
 const SCHEMA_URL = "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json";

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -222,7 +222,7 @@ function handleOmoShow(
     let globalConfigPath = "";
     let projectConfigPath = "";
 
-    // Get global TARGET config from ~/.config/opencode/oh-my-opencode.jsonc (or .json)
+    // Get global TARGET config from ~/.config/opencode/oh-my-openagent.jsonc (or .json)
     const globalTargetResult = findExistingConfigPath();
     if (globalTargetResult && globalTargetResult.exists) {
       globalConfigPath = globalTargetResult.path;

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -234,7 +234,7 @@ function handleOmoShow(
       }
     }
 
-    // Get project TARGET config from <project>/.opencode/oh-my-opencode.jsonc (or .json)
+    // Get project TARGET config: checks oh-my-openagent.json(c) then falls back to oh-my-opencode.json(c)
     if (projectRoot) {
       const projectTargetJsonc = getProjectTargetPath(projectRoot);
       const projectTargetJson = projectTargetJsonc.replace(/\.jsonc$/, ".json");

--- a/src/store/index.test.ts
+++ b/src/store/index.test.ts
@@ -162,10 +162,10 @@ describe("StoreManager", () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       const store = new StoreManager();
 
-      const backupPath = store.createBackup("/test/oh-my-opencode.json");
+      const backupPath = store.createBackup("/test/oh-my-openagent.json");
 
       expect(backupPath).toBeTruthy();
-      expect(backupPath).toContain("oh-my-opencode.json");
+      expect(backupPath).toContain("oh-my-openagent.json");
       expect(fs.copyFileSync).toHaveBeenCalled();
     });
   });

--- a/src/store/project-store.test.ts
+++ b/src/store/project-store.test.ts
@@ -13,7 +13,7 @@ vi.mock("fs", () => ({
 
 vi.mock("../utils/scope-resolver", () => ({
   getProjectConfigsPath: vi.fn((root: string) => `${root}/.opencode/omo-configs`),
-  getProjectTargetPath: vi.fn((root: string) => `${root}/.opencode/oh-my-opencode.jsonc`),
+  getProjectTargetPath: vi.fn((root: string) => `${root}/.opencode/oh-my-openagent.jsonc`),
   getProjectRcPath: vi.fn((root: string) => `${root}/.opencode/.omorc`),
   loadProjectRc: vi.fn(() => null),
   saveProjectRc: vi.fn(),
@@ -39,7 +39,7 @@ describe("ProjectStoreManager", () => {
       expect(store.getConfigsPath()).toContain(".opencode");
       expect(store.getConfigsPath()).toContain("omo-configs");
       expect(store.getTargetPath()).toContain(".opencode");
-      expect(store.getTargetPath()).toContain("oh-my-opencode");
+      expect(store.getTargetPath()).toContain("oh-my-openagent");
       expect(store.getTargetPath()).toContain(".jsonc");
       expect(store.getRcPath()).toContain(".opencode");
       expect(store.getRcPath()).toContain(".omorc");
@@ -191,19 +191,19 @@ describe("ProjectStoreManager", () => {
       vi.mocked(fs.existsSync).mockImplementation((p) => {
         const pStr = String(p);
         // Source file exists
-        if (pStr.endsWith("oh-my-opencode.json")) return true;
+        if (pStr.endsWith("oh-my-openagent.json")) return true;
         // Backups dir does NOT exist (so mkdirSync should be called)
         return false;
       });
 
-      const backupPath = store.createBackup("/test/oh-my-opencode.json");
+      const backupPath = store.createBackup("/test/oh-my-openagent.json");
 
       expect(fs.mkdirSync).toHaveBeenCalledWith(
         expect.stringMatching(/backups/),
         { recursive: true }
       );
       expect(backupPath).toBeTruthy();
-      expect(path.normalize(backupPath!)).toContain("oh-my-opencode.json");
+      expect(path.normalize(backupPath!)).toContain("oh-my-openagent.json");
       const copyCall = vi.mocked(fs.copyFileSync).mock.calls[0];
       expect(copyCall).toBeTruthy();
     });

--- a/src/store/project-store.ts
+++ b/src/store/project-store.ts
@@ -10,6 +10,7 @@ import {
   loadProjectRc,
   saveProjectRc,
   ensureProjectDirs,
+  ALL_PROJECT_CONFIG_FILES,
 } from "../utils/scope-resolver";
 
 const OPENCODE_DIR = ".opencode";
@@ -40,6 +41,17 @@ export class ProjectStoreManager {
 
   getTargetPath(): string {
     return this.targetPath;
+  }
+
+  findExistingTargetConfig(): string | null {
+    const opencodeDir = path.join(this.projectRoot, OPENCODE_DIR);
+    for (const file of ALL_PROJECT_CONFIG_FILES) {
+      const configPath = path.join(opencodeDir, file);
+      if (fs.existsSync(configPath)) {
+        return configPath;
+      }
+    }
+    return null;
   }
 
   getRcPath(): string {

--- a/src/utils/config-path.test.ts
+++ b/src/utils/config-path.test.ts
@@ -32,8 +32,8 @@ describe("config-path", () => {
       process.env.USERPROFILE = "C:/Users/test";
       process.env.APPDATA = "C:/Users/test/AppData/Roaming";
 
-      const preferredJsonc = join(process.env.USERPROFILE, ".config", "opencode", "oh-my-opencode.jsonc");
-      const preferredJson = join(process.env.USERPROFILE, ".config", "opencode", "oh-my-opencode.json");
+      const preferredJsonc = join(process.env.USERPROFILE, ".config", "opencode", "oh-my-openagent.jsonc");
+      const preferredJson = join(process.env.USERPROFILE, ".config", "opencode", "oh-my-openagent.json");
 
       vi.mocked(fs.existsSync).mockImplementation((p) => p === preferredJsonc || p === preferredJson);
 
@@ -64,7 +64,7 @@ describe("config-path", () => {
       process.env.USERPROFILE = "C:/Users/test";
       process.env.APPDATA = "C:/Users/test/AppData/Roaming";
 
-      const preferredPath = join(process.env.USERPROFILE, ".config", "opencode", "oh-my-opencode.json");
+      const preferredPath = join(process.env.USERPROFILE, ".config", "opencode", "oh-my-openagent.json");
       vi.mocked(fs.existsSync).mockImplementation((p) => p === preferredPath);
 
       expect(getConfigTargetPath()).toEqual({ path: preferredPath, isPreferred: true });
@@ -79,7 +79,7 @@ describe("config-path", () => {
 
     it("findExistingConfigPath uses XDG_CONFIG_HOME when set", () => {
       process.env.XDG_CONFIG_HOME = "/xdg";
-      const jsoncPath = join("/xdg", "opencode", "oh-my-opencode.jsonc");
+      const jsoncPath = join("/xdg", "opencode", "oh-my-openagent.jsonc");
       vi.mocked(fs.existsSync).mockImplementation((p) => p === jsoncPath);
 
       expect(findExistingConfigPath()).toEqual({ path: jsoncPath, exists: true });

--- a/src/utils/config-path.ts
+++ b/src/utils/config-path.ts
@@ -17,9 +17,7 @@ function findConfigInDir(dir: string): { path: string; exists: boolean } | null 
 }
 
 export function findExistingConfigPath(): { path: string; exists: boolean } | null {
-  const isWindows = os.platform() === "win32";
-
-  if (isWindows) {
+  if (os.platform() === "win32") {
     const userProfile = process.env.USERPROFILE || os.homedir();
     const appData = process.env.APPDATA || path.join(userProfile, "AppData", "Roaming");
 
@@ -45,9 +43,7 @@ export function findExistingConfigPath(): { path: string; exists: boolean } | nu
 }
 
 export function getConfigTargetDir(): { dir: string; isPreferred: boolean } {
-  const isWindows = os.platform() === "win32";
-
-  if (isWindows) {
+  if (os.platform() === "win32") {
     const userProfile = process.env.USERPROFILE || os.homedir();
     const appData = process.env.APPDATA || path.join(userProfile, "AppData", "Roaming");
 
@@ -73,13 +69,9 @@ export function getConfigTargetPath(): { path: string; isPreferred: boolean } {
     return { path: existingConfig.path, isPreferred: true };
   }
 
-  const isWindows = os.platform() === "win32";
-
-  if (isWindows) {
+  if (os.platform() === "win32") {
     const userProfile = process.env.USERPROFILE || os.homedir();
-
     const preferredPath = path.join(userProfile, ".config", "opencode", "oh-my-openagent.json");
-
     return { path: preferredPath, isPreferred: true };
   }
 

--- a/src/utils/config-path.ts
+++ b/src/utils/config-path.ts
@@ -2,116 +2,89 @@ import * as os from "os";
 import * as path from "path";
 import * as fs from "fs";
 
-/**
- * Find existing config file at user config location.
- * Priority: .jsonc > .json
- * Returns null if neither exists.
- */
-export function findExistingConfigPath(): { path: string; exists: boolean } | null {
-  const isWindows = os.platform() === "win32";
-  
-  if (isWindows) {
-    const userProfile = process.env.USERPROFILE || os.homedir();
-    const appData = process.env.APPDATA || path.join(userProfile, "AppData", "Roaming");
-    
-    // Check preferred location first
-    const preferredDir = path.join(userProfile, ".config", "opencode");
-    const fallbackDir = path.join(appData, "opencode");
-    
-    // Check jsonc then json in preferred location
-    const preferredJsonc = path.join(preferredDir, "oh-my-opencode.jsonc");
-    const preferredJson = path.join(preferredDir, "oh-my-opencode.json");
-    
-    if (fs.existsSync(preferredJsonc)) {
-      return { path: preferredJsonc, exists: true };
+export const NEW_AGENT_CONFIG_FILES = ["oh-my-openagent.jsonc", "oh-my-openagent.json"] as const;
+export const LEGACY_CONFIG_FILES = ["oh-my-opencode.jsonc", "oh-my-opencode.json"] as const;
+export const ALL_CONFIG_FILES = [...NEW_AGENT_CONFIG_FILES, ...LEGACY_CONFIG_FILES] as const;
+
+function findConfigInDir(dir: string): { path: string; exists: boolean } | null {
+  for (const file of ALL_CONFIG_FILES) {
+    const configPath = path.join(dir, file);
+    if (fs.existsSync(configPath)) {
+      return { path: configPath, exists: true };
     }
-    if (fs.existsSync(preferredJson)) {
-      return { path: preferredJson, exists: true };
-    }
-    
-    // Check fallback location
-    const fallbackJsonc = path.join(fallbackDir, "oh-my-opencode.jsonc");
-    const fallbackJson = path.join(fallbackDir, "oh-my-opencode.json");
-    
-    if (fs.existsSync(fallbackJsonc)) {
-      return { path: fallbackJsonc, exists: true };
-    }
-    if (fs.existsSync(fallbackJson)) {
-      return { path: fallbackJson, exists: true };
-    }
-    
-    return null;
   }
-  
-  // Unix/macOS
-  const configHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
-  const configDir = path.join(configHome, "opencode");
-  
-  const jsoncPath = path.join(configDir, "oh-my-opencode.jsonc");
-  const jsonPath = path.join(configDir, "oh-my-opencode.json");
-  
-  if (fs.existsSync(jsoncPath)) {
-    return { path: jsoncPath, exists: true };
-  }
-  if (fs.existsSync(jsonPath)) {
-    return { path: jsonPath, exists: true };
-  }
-  
   return null;
 }
 
-/**
- * Get the directory path for user config (for writing new files).
- * Caller decides the filename/extension.
- */
-export function getConfigTargetDir(): { dir: string; isPreferred: boolean } {
+export function findExistingConfigPath(): { path: string; exists: boolean } | null {
   const isWindows = os.platform() === "win32";
-  
+
   if (isWindows) {
     const userProfile = process.env.USERPROFILE || os.homedir();
     const appData = process.env.APPDATA || path.join(userProfile, "AppData", "Roaming");
-    
+
     const preferredDir = path.join(userProfile, ".config", "opencode");
     const fallbackDir = path.join(appData, "opencode");
-    
-    // Check if any config exists in either location to determine preference
+
+    const preferredResult = findConfigInDir(preferredDir);
+    if (preferredResult) return preferredResult;
+
+    const fallbackResult = findConfigInDir(fallbackDir);
+    if (fallbackResult) return fallbackResult;
+
+    return null;
+  }
+
+  const configHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  const configDir = path.join(configHome, "opencode");
+
+  const result = findConfigInDir(configDir);
+  if (result) return result;
+
+  return null;
+}
+
+export function getConfigTargetDir(): { dir: string; isPreferred: boolean } {
+  const isWindows = os.platform() === "win32";
+
+  if (isWindows) {
+    const userProfile = process.env.USERPROFILE || os.homedir();
+    const appData = process.env.APPDATA || path.join(userProfile, "AppData", "Roaming");
+
+    const preferredDir = path.join(userProfile, ".config", "opencode");
+
     const existingConfig = findExistingConfigPath();
     if (existingConfig) {
       const dir = path.dirname(existingConfig.path);
       return { dir, isPreferred: dir === preferredDir };
     }
-    
-    // Default to preferred location for new files
+
     return { dir: preferredDir, isPreferred: true };
   }
-  
+
   const configHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
   const configDir = path.join(configHome, "opencode");
   return { dir: configDir, isPreferred: true };
 }
 
 export function getConfigTargetPath(): { path: string; isPreferred: boolean } {
+  const existingConfig = findExistingConfigPath();
+  if (existingConfig) {
+    return { path: existingConfig.path, isPreferred: true };
+  }
+
   const isWindows = os.platform() === "win32";
-  
+
   if (isWindows) {
     const userProfile = process.env.USERPROFILE || os.homedir();
-    const appData = process.env.APPDATA || path.join(userProfile, "AppData", "Roaming");
-    
-    const preferredPath = path.join(userProfile, ".config", "opencode", "oh-my-opencode.json");
-    const fallbackPath = path.join(appData, "opencode", "oh-my-opencode.json");
-    
-    const preferredExists = fs.existsSync(preferredPath);
-    const fallbackExists = fs.existsSync(fallbackPath);
-    
-    if (preferredExists || !fallbackExists) {
-      return { path: preferredPath, isPreferred: true };
-    }
-    
-    return { path: fallbackPath, isPreferred: false };
+
+    const preferredPath = path.join(userProfile, ".config", "opencode", "oh-my-openagent.json");
+
+    return { path: preferredPath, isPreferred: true };
   }
-  
+
   const configHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
-  const configPath = path.join(configHome, "opencode", "oh-my-opencode.json");
+  const configPath = path.join(configHome, "opencode", "oh-my-openagent.json");
   return { path: configPath, isPreferred: true };
 }
 

--- a/src/utils/scope-resolver.test.ts
+++ b/src/utils/scope-resolver.test.ts
@@ -90,7 +90,7 @@ describe("scope-resolver", () => {
       expect(configsPath).toContain(".opencode");
       expect(configsPath).toContain("omo-configs");
       expect(targetPath).toContain(".opencode");
-      expect(targetPath).toContain("oh-my-opencode");
+      expect(targetPath).toContain("oh-my-openagent");
       expect(targetPath).toContain("jsonc");
       expect(rcPath).toContain(".opencode");
       expect(rcPath).toContain(".omorc");

--- a/src/utils/scope-resolver.ts
+++ b/src/utils/scope-resolver.ts
@@ -4,8 +4,15 @@ import { ProjectRc } from "../store/types";
 
 const OPENCODE_DIR = ".opencode";
 const OMO_CONFIGS_DIR = "omo-configs";
-const TARGET_CONFIG_FILE = "oh-my-opencode.jsonc";
 const PROJECT_RC_FILE = ".omorc";
+
+export const NEW_AGENT_CONFIG_FILE = "oh-my-openagent.jsonc";
+export const ALL_PROJECT_CONFIG_FILES = [
+  "oh-my-openagent.jsonc",
+  "oh-my-openagent.json",
+  "oh-my-opencode.jsonc",
+  "oh-my-opencode.json",
+] as const;
 
 /**
  * Traverse UP from startDir looking for .opencode/ directory.
@@ -48,10 +55,10 @@ export function getProjectConfigsPath(projectRoot: string): string {
 }
 
 /**
- * Returns <projectRoot>/.opencode/oh-my-opencode.jsonc
+ * Returns <projectRoot>/.opencode/oh-my-openagent.jsonc (default write target)
  */
 export function getProjectTargetPath(projectRoot: string): string {
-  return path.join(projectRoot, OPENCODE_DIR, TARGET_CONFIG_FILE);
+  return path.join(projectRoot, OPENCODE_DIR, NEW_AGENT_CONFIG_FILE);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Renames the target config file from `oh-my-opencode.jsonc` to `oh-my-openagent.jsonc` ([oh-my-openagent#3055](https://github.com/code-yeongyu/oh-my-openagent/pull/3055))
- **Backward compatible**: automatically falls back to existing `oh-my-opencode.jsonc` if no new file exists
  - Priority: `oh-my-openagent.jsonc` > `oh-my-openagent.json` > `oh-my-opencode.jsonc` > `oh-my-opencode.json`

## Changes

- **`src/utils/config-path.ts`**: Introduced `NEW_AGENT_CONFIG_FILES`, `LEGACY_CONFIG_FILES`, and `ALL_CONFIG_FILES` constants. Extracted `findConfigInDir()` helper for DRY 4-file traversal. Updated `getConfigTargetPath()` and `getConfigTargetDir()` to use new priority order.
- **`src/utils/scope-resolver.ts`**: Exported `NEW_AGENT_CONFIG_FILE` and `ALL_PROJECT_CONFIG_FILES` for project-level config resolution.
- **`src/store/project-store.ts`**: Added `findExistingTargetConfig()` to locate existing target config (including legacy filenames) for proper backup creation before writes.
- **`src/commands/apply.ts`**: User scope now writes to `oh-my-openagent.jsonc`. Backup loop iterates all 4 filename variants instead of just 2. Project scope uses `findExistingTargetConfig()` instead of blindly backing up the canonical path.
- **`src/commands/init.ts`**: Default profile creation now targets `oh-my-openagent.jsonc`.
- **Tests**: Updated all mock paths, assertions, and the `config-path` mock to include `ALL_CONFIG_FILES`.
- **README**: Updated all user-facing target path references (schema and slim filenames unchanged).

## Verification

- ✅ `npm run build` — clean
- ✅ `npm test` — 18/18 passed, 185 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply now detects existing config files (new and legacy names) and backs up the first match automatically.
  * Project config default target name updated to the new agent-style filename.

* **Documentation**
  * Updated docs to use the new config filename and adjusted example paths and backup references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->